### PR TITLE
fix(thermostat_TPI): fix logical error for non climate entities

### DIFF
--- a/blueprint/Thermostat_TPI__by_C.yaml
+++ b/blueprint/Thermostat_TPI__by_C.yaml
@@ -374,9 +374,9 @@ variables:
       climate.set_preset_mode
     {%- else -%}
       {%- if entity_mode_inverse -%}
-        switch.turn_on
-      {%- else -%}
         switch.turn_off
+      {%- else -%}
+        switch.turn_on
       {%- endif -%}
     {%- endif -%}
 
@@ -385,9 +385,9 @@ variables:
       climate.set_preset_mode
     {%- else -%}
       {%- if entity_mode_inverse -%}
-        switch.turn_off
-      {%- else -%}
         switch.turn_on
+      {%- else -%}
+        switch.turn_off
       {%- endif -%}
     {%- endif -%}
 


### PR DESCRIPTION
Hi,

I could not report the issue on github so here is a PR.

For non climate entities, I belive there is an error when handling switches for service on/off.

Thank you for sharing your work !